### PR TITLE
Update config.py

### DIFF
--- a/src/myprox/config.py
+++ b/src/myprox/config.py
@@ -104,7 +104,7 @@ class Configuration():
     @property
     def url(self):
         """Get url of our webserver"""
-        scheme = f'http{'s' if self.use_ssl else ''}'
+        scheme = f"http{'s' if self.use_ssl else ''}"
         fqdn = socket.getfqdn()
         port = self.socket_port
         if (scheme == 'http') and (port == 80):


### PR DESCRIPTION
Fixed an outer ' to " .. the old codes didn't work for me, but fix was easy

 Traceback (most recent call last):
   File "/etc/myprox/.venv/bin/myprox", line 5, in <module>
     from myprox import main
   File "/etc/myprox/.venv/lib64/python3.9/site-packages/myprox/__init__.py", >
     from . import config
   File "/etc/myprox/.venv/lib64/python3.9/site-packages/myprox/config.py", li>
     scheme = f'http{'s' if self.use_ssl else ''}'
                      ^
 SyntaxError: f-string: expecting '}'
myprox.service: Main process exited, code=exited, status=1/FAILURE